### PR TITLE
Release version 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ pip install openai-api-call --upgrade
 ### Set API Key
 
 ```py
-import openai
-openai.api_key = "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+import openai_api_call
+openai_api_call.api_key = "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
 Or set `OPENAI_API_KEY` in `~/.bashrc` to automatically set it when you start the terminal:
@@ -43,7 +43,7 @@ from openai_api_call import proxy_on, proxy_off, proxy_status
 proxy_status()
 
 # Set proxy(example)
-proxy_on(http="127.0.0.1:7890", https="socks://127.0.0.1:7891")
+proxy_on(http="127.0.0.1:7890", https="127.0.0.1:7890")
 
 # Check the updated proxy
 proxy_status()
@@ -67,7 +67,7 @@ proxy_status()
 
 # Send prompt and return response
 chat = Chat("Hello, GPT-3.5!")
-resp = chat.getresponse(update=False) # Do not update the chat history, default is True
+resp = chat.getresponse(update=False) # Not update the chat history, default to True
 ```
 
 Example 2, customize the message template and return the information and the number of consumed tokens:
@@ -115,6 +115,7 @@ chat.print_log()
 
 This package is licensed under the MIT license. See the LICENSE file for more details.
 
-## Features
+## update log
 
-* update documentation of the repo.
+- Since version `0.2.0`, `Chat` type is used to handle data
+- Since version `0.3.0`, you can use different API Key to send requests.

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -22,8 +22,8 @@ pip install openai-api-call --upgrade
 ### 设置 API 密钥
 
 ```py
-import openai
-openai.api_key = "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+import openai_api_call
+openai_api_call.api_key = "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
 或者直接在 `~/.bashrc` 中设置 `OPENAI_API_KEY`，每次启动终端可以自动设置：
@@ -41,7 +41,7 @@ from openai_api_call import proxy_on, proxy_off, proxy_status
 proxy_status()
 
 # 设置代理，这里 IP 127.0.0.1 代表本机
-proxy_on(http="127.0.0.1:7890", https="socks://127.0.0.1:7891")
+proxy_on(http="127.0.0.1:7890", https="127.0.0.1:7890")
 
 # 查看更新后的代理
 proxy_status()
@@ -111,6 +111,7 @@ chat.print_log()
 
 这个项目使用 MIT 协议开源。
 
-## 未来计划
+## 更新日志
 
-* 更新仓库文档
+- 版本 `0.2.0` 开始改用 `Chat` 类型作为中心交互对象
+- 版本 `0.3.0` 允许使用不同 API Key 发送请求，也即不以 `openai.py` 作为依赖

--- a/openai_api_call/__init__.py
+++ b/openai_api_call/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Rex Wang"""
 __email__ = '1073853456@qq.com'
-__version__ = '0.2.3'
+__version__ = '0.3.0'
 
 import os
 from .chattool import Chat, Resp, chat_completion

--- a/openai_api_call/chattool.py
+++ b/openai_api_call/chattool.py
@@ -74,7 +74,7 @@ class Chat():
                 signal.alarm(timeout)
                 # Make the API call
                 response = chat_completion(
-                    api_key, messages=msg, model=model, **options)
+                    api_key=api_key, messages=msg, model=model, **options)
                 time.sleep(random.random() * timeinterval)
                 resp = Resp(response, strip=strip)
                 break

--- a/openai_api_call/chattool.py
+++ b/openai_api_call/chattool.py
@@ -74,7 +74,7 @@ class Chat():
                 signal.alarm(timeout)
                 # Make the API call
                 response = chat_completion(
-                    api_key=api_key, messages=msg, model=model, **options)
+                    api_key, messages=msg, model=model, **options)
                 time.sleep(random.random() * timeinterval)
                 resp = Resp(response, strip=strip)
                 break

--- a/openai_api_call/request.py
+++ b/openai_api_call/request.py
@@ -1,8 +1,7 @@
 # rewrite the request function
 
 from typing import List, Dict
-import requests
-import json
+import requests, json
 url = "https://api.openai.com/v1/chat/completions"
 
 ## TODO: catch error types

--- a/openai_api_call/request.py
+++ b/openai_api_call/request.py
@@ -6,12 +6,12 @@ import json
 url = "https://api.openai.com/v1/chat/completions"
 
 ## TODO: catch error types
-def chat_completion(apikey:str, msg:List[Dict], model:str, **options) -> Dict:
+def chat_completion(apikey:str, messages:List[Dict], model:str, **options) -> Dict:
     """Chat completion API call
     
     Args:
         apikey (str): API key
-        msg (List[Dict]): prompt message
+        messages (List[Dict]): prompt message
         model (str): model to use
         **options : options inherited from the `openai.ChatCompletion.create` function.
     
@@ -21,7 +21,7 @@ def chat_completion(apikey:str, msg:List[Dict], model:str, **options) -> Dict:
     # request data
     payload = {
         "model": model,
-        "messages": msg
+        "messages": messages
     }
     # inherit options
     payload.update(options)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md') as readme_file:
 
 VERSION = '0.2.3'
 
-requirements = ['Click>=7.0', 'requests>=2.0']
+requirements = ['Click>=7.0', 'requests>=2.20']
 
 test_requirements = ['pytest>=3', 'unittest']
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
-VERSION = '0.2.3'
+VERSION = '0.3.0'
 
 requirements = ['Click>=7.0', 'requests>=2.20']
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,4 +1,4 @@
-import requests, responses
+import responses
 from openai_api_call import chat_completion
 
 mock_resp = {
@@ -27,7 +27,7 @@ mock_resp = {
 def test_chat_completion():
     responses.add(responses.POST, 'https://api.openai.com/v1/chat/completions',
                   json=mock_resp, status=200)
-    resp = chat_completion(apikey="sk-123", msg=[{"role": "user", "content": "hello"}], model="gpt-3.5-turbo")
+    resp = chat_completion(apikey="sk-123", messages=[{"role": "user", "content": "hello"}], model="gpt-3.5-turbo")
     assert resp == mock_resp
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == 'https://api.openai.com/v1/chat/completions'


### PR DESCRIPTION
Use `chat_completion` instead of `openai.ChatCompletion.create` to allow the use of different apikeys.
```py
def chat_completion(apikey:str, msg:List[Dict], model:str, **options) -> Dict:
    """Chat completion API call
    
    Args:
        apikey (str): API key
        msg (List[Dict]): prompt message
        model (str): model to use
        **options : options inherited from the `openai.ChatCompletion.create` function.
    
    Returns:
        Dict: API response
    """
    # request data
    payload = {
        "model": model,
        "messages": msg
    }
    # inherit options
    payload.update(options)
    # request headers
    headers = {
        'Content-Type': 'application/json',
        'Authorization': 'Bearer ' + apikey
    }
    # get response
    response = requests.post(url, headers=headers, data=json.dumps(payload))
    return response.json()
```
